### PR TITLE
Fix NoMethodError: `min_wait` in RetryOn429

### DIFF
--- a/lib/shopify_api_mixins/retry_on429.rb
+++ b/lib/shopify_api_mixins/retry_on429.rb
@@ -20,7 +20,7 @@ module ShopifyApiMixins
           case code = e.response.code.to_i
           when 429
             wait_time = e.response['Retry-After'].to_i
-            wait_time = min_wait if wait_time < RetryOn429.min_wait
+            wait_time = RetryOn429.min_wait if wait_time < RetryOn429.min_wait
             logger&.warn "Got a 429, will retry in #{wait_time} seconds"
             sleep(wait_time)
             next


### PR DESCRIPTION
When I last updated this code in https://github.com/mikeyhew/shopify_api_mixins/commit/e04d0f5f04570089395584c6ca85bb47a028d074, I didn't update this call to `min_wait`. The bug went unnoticed because I never encountered the case where `wait_time < min_wait`. This fixes that.

I spent more time than I am proud of today, trying to figure out *why* I decided not to make `min_wait` and `max_retries` methods on the connection object itself. Then I realized that they would be in the same namespace as other methods on `Connection`, and I'd have to add `_on_429` or `_on_5xx` to the end of the methods to avoid conflicts. Rather than do that, I decided to just put the methods on the prepended modules themselves.

There's a problem with that, too: if someone had more than one connection class and called `retry_on_429` on both of them, with different settings, the second call to `retry_on_429` would overwrite the existing settings from the first call. Oh well, we'll cross that bridge when we get to it :)