### PR TITLE
Put homepage url in gemspec

### DIFF
--- a/shopify_api_mixins.gemspec
+++ b/shopify_api_mixins.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["michael@michaelhewson.ca"]
 
   spec.summary       = %q{Useful mixins for working with the shopify_api gem}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/mikeyhew/shopify_api_mixins"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
it will prevent bundler throwing:
```zsh
The gemspec at
/home/username/.bundle/ruby/rubyversion/shopify_api_mixins-179c23164e99/shopify_api_mixins.gemspec
is not valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo
URL here." is not a URI'
```